### PR TITLE
Refactor/crs label select logic

### DIFF
--- a/internal/k8s/sync.go
+++ b/internal/k8s/sync.go
@@ -209,7 +209,7 @@ func getCRForGroupKindWithLabel(group, kind, labelName, labelValue string, dynCl
 	// Label selector to filter CRs
 	labelSelector := labels.SelectorFromSet(labels.Set{labelName: labelValue})
 
-	// // Fetch the list of CRs and filter by username
+	// Fetch the list of CRs and filter by username
 	crs, err := dynClient.Resource(resource).Namespace("default").List(context.Background(), v1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
@@ -249,7 +249,7 @@ func (client *Client) AssertPassword(username string, password string) bool {
 	logger := misc.GetLogger()
 	userWithPassword, err := getUserWithPasswordByUsername(username, client.k8sDynClient)
 	if err != nil {
-		logger.Warnf("%s", err.Error())
+		logger.Warnf("could not get user by username: %s", err.Error())
 		return false
 	}
 

--- a/internal/k8s/sync.go
+++ b/internal/k8s/sync.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -212,8 +213,11 @@ func getCRForGroupKindWithLabel(group, kind, labelName, labelValue string, dynCl
 	crs, err := dynClient.Resource(resource).Namespace("default").List(context.Background(), v1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	})
-	if err != nil || len(crs.Items) == 0 {
-		return &unstructured.Unstructured{}, err
+	if err != nil {
+		return nil, err
+	}
+	if len(crs.Items) == 0 {
+		return nil, fmt.Errorf("no CR With label %s and value %s found", labelName, labelValue)
 	}
 
 	return &crs.Items[0], nil

--- a/internal/k8s/sync.go
+++ b/internal/k8s/sync.go
@@ -306,15 +306,13 @@ func (c *Client) ConfigWithWatcher(gcfg *config.Config, wg *sync.WaitGroup) {
 
 	go func() {
 		for {
-			select {
-			case event, ok := <-watcher.ResultChan():
-				if !ok {
-					logger.Info("Watcher channel closed")
-					return
-				}
-				logger.Infof("event received: %+v", event)
-				eventHandler(event.Object)
+			event, ok := <-watcher.ResultChan()
+			if !ok {
+				logger.Info("Watcher channel closed")
+				return
 			}
+			logger.Infof("event received: %+v", event)
+			eventHandler(event.Object)
 		}
 	}()
 }

--- a/resources/k8s-examples/UserExample.yaml
+++ b/resources/k8s-examples/UserExample.yaml
@@ -2,8 +2,6 @@ apiVersion: iam-backbone.org/v1
 kind: BackboneUser
 metadata:
   name: admin-user
-  labels:
-    email: omri__at__gopher.com
 spec:
   email: omri@gopher.com
   firstName: Omri


### PR DESCRIPTION
Removed the need for an email label in the user role cr, by adding filter logic of the username.

Fixed a small type check of go in the infinite for loop with the select statement.